### PR TITLE
Updated IsActiveAsync to also check for verified accounts

### DIFF
--- a/source/IdentityServer3.MembershipReboot/IdentityServer3.MembershipReboot.cs
+++ b/source/IdentityServer3.MembershipReboot/IdentityServer3.MembershipReboot.cs
@@ -343,7 +343,7 @@ namespace IdentityServer3.MembershipReboot
 
             var acct = userAccountService.GetByID(subject.GetSubjectId().ToGuid());
             
-            ctx.IsActive = acct != null && !acct.IsAccountClosed && acct.IsLoginAllowed;
+            ctx.IsActive = acct != null && !acct.IsAccountClosed && acct.IsLoginAllowed && acct.IsAccountVerified;
 
             return Task.FromResult(0);
         }


### PR DESCRIPTION
Added a check to ensure expected behavior on "IsActiveAsync". A useraccount who is authenticated and verified is an active useraccount. For all other scenarios "IsActive" should return "False". See #44